### PR TITLE
CPUを使っての推論を可能に

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -49,7 +49,7 @@ def inference(args):
         len(symbols),
         hps.data.filter_length // 2 + 1,
         hps.train.segment_size // hps.data.hop_length,
-        **hps.model).cuda()
+        **hps.model).to(device)
     _ = net_g.eval()
     _ = utils.load_checkpoint(G_model_path, net_g, None)
 
@@ -71,8 +71,8 @@ def inference(args):
         stn_phn = pyopenjtalk_g2p_prosody("速度計測のためのダミーインプットです。")
         stn_tst = get_text(stn_phn, hps)
         # generate audio
-        x_tst = stn_tst.cuda().unsqueeze(0)
-        x_tst_lengths = torch.LongTensor([stn_tst.size(0)]).cuda()
+        x_tst = stn_tst.to(device).unsqueeze(0)
+        x_tst_lengths = torch.LongTensor([stn_tst.size(0)]).to(device)
         audio = net_g.infer(x_tst, 
                             x_tst_lengths, 
                             noise_scale=noise_scale, 
@@ -88,7 +88,8 @@ def inference(args):
             break
         
         # measure the execution time 
-        torch.cuda.synchronize()
+        if device=="cuda:0":
+            torch.cuda.synchronize()
         start = time.time()
 
         # required_grad is False
@@ -97,8 +98,8 @@ def inference(args):
             stn_tst = get_text(stn_phn, hps)
 
             # generate audio
-            x_tst = stn_tst.cuda().unsqueeze(0)
-            x_tst_lengths = torch.LongTensor([stn_tst.size(0)]).cuda()
+            x_tst = stn_tst.to(device).unsqueeze(0)
+            x_tst_lengths = torch.LongTensor([stn_tst.size(0)]).to(device)
             audio = net_g.infer(x_tst, 
                                 x_tst_lengths, 
                                 noise_scale=noise_scale, 
@@ -106,7 +107,8 @@ def inference(args):
                                 length_scale=length_scale)[0][0,0].data.cpu().float().numpy()
 
         # measure the execution time 
-        torch.cuda.synchronize()
+        if device=="cuda:0":
+            torch.cuda.synchronize()
         elapsed_time = time.time() - start
         print(f"Gen Time : {elapsed_time}")
         

--- a/models.py
+++ b/models.py
@@ -459,7 +459,7 @@ class Multistream_iSTFT_Generator(torch.nn.Module):
       y_mb_hat = torch.reshape(y_mb_hat, (x.shape[0], self.subbands, 1, y_mb_hat.shape[-1]))
       y_mb_hat = y_mb_hat.squeeze(-2)
 
-      y_mb_hat = F.conv_transpose1d(y_mb_hat, self.updown_filter.cuda(x.device) * self.subbands, stride=self.subbands)
+      y_mb_hat = F.conv_transpose1d(y_mb_hat, self.updown_filter.to(x.device) * self.subbands, stride=self.subbands)
 
       y_g_hat = self.multistream_conv_post(y_mb_hat)
 


### PR DESCRIPTION
### 概要

inference 実行時に cpu を指定した場合は cpu で実行可能にした。

### 背景

inference.py で device を指定可能になっていたが、実際には cpu を指定しても常に gpu モードでの実行になっていた。

### 変更内容

`.cuda()` 部分を `.to(device)` に置き換えました。
models.py 内でも固定で `.cuda()` としているコードが一つあったため、そこも併せて修正しています。

### テスト

inference.py が gpu/cpu ともに正常に実行でき、意図したとおり gpu 指定時は gpu で、cpu 指定時は gpu を使わずに動いたことを確認しました。
ただし、train の方は実行していないため、models.py の変更の影響をすべてはチェックできていません。

### 備考

[Issue](https://github.com/tonnetonne814/MB-iSTFT-VITS-44100-Ja/issues/1) を別途上げました  